### PR TITLE
kernel: use proper header files

### DIFF
--- a/znedi3/kernel.cpp
+++ b/znedi3/kernel.cpp
@@ -4,7 +4,7 @@
 #include <cfloat>
 #include <cmath>
 #include <cstdint>
-#include <limits>
+#include <climits>
 #include <memory>
 #include "kernel.h"
 #include "weights.h"

--- a/znedi3/x86/kernel_sse.cpp
+++ b/znedi3/x86/kernel_sse.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <xmmintrin.h>
+#include <climits>
 #include "alloc.h"
 #include "ccdep.h"
 #include "kernel.h"

--- a/znedi3/x86/kernel_sse2.cpp
+++ b/znedi3/x86/kernel_sse2.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <emmintrin.h>
+#include <cfloat>
 #include "kernel.h"
 #include "kernel_x86.h"
 

--- a/znedi3/x86/kernel_x86.cpp
+++ b/znedi3/x86/kernel_x86.cpp
@@ -1,6 +1,7 @@
 #ifdef ZNEDI3_X86
 
 #include <cassert>
+#include <algorithm>
 #include "alloc.h"
 #include "cpuinfo.h"
 #include "cpuinfo_x86.h"


### PR DESCRIPTION
It won't compile on Linux/G++ without this change. 